### PR TITLE
Remove trailing space from first line of systemd_user_preun

### DIFF
--- a/macros.systemd
+++ b/macros.systemd
@@ -53,7 +53,7 @@ fi \
 %{nil}
 
 %systemd_user_preun() \
-if [ "$1" = "remove" ] || [ "$1" = "purge" ]; then\ 
+if [ "$1" = "remove" ] || [ "$1" = "purge" ]; then\
         # Package removal, not upgrade \
         systemctl --no-reload --user --global disable %{?*} > /dev/null 2>&1 || : \
 fi \


### PR DESCRIPTION
Fixes https://github.com/debbuild/debbuild/issues/216 by removing trailing space from the first line of `systemd_user_preun` definition.