### PR TITLE
python: Add shebang pathfix macros and helper script

### DIFF
--- a/LICENSE-PSF-2.0
+++ b/LICENSE-PSF-2.0
@@ -1,0 +1,47 @@
+PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
+
+1. This LICENSE AGREEMENT is between the Python Software Foundation
+("PSF"), and the Individual or Organization ("Licensee") accessing and
+otherwise using this software ("Python") in source or binary form and
+its associated documentation.
+
+2. Subject to the terms and conditions of this License Agreement, PSF hereby
+grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,
+analyze, test, perform and/or display publicly, prepare derivative works,
+distribute, and otherwise use Python alone or in any derivative version,
+provided, however, that PSF's License Agreement and PSF's notice of copyright,
+i.e., "Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
+2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019 Python Software Foundation;
+All Rights Reserved" are retained in Python alone or in any derivative version
+prepared by Licensee.
+
+3. In the event Licensee prepares a derivative work that is based on
+or incorporates Python or any part thereof, and wants to make
+the derivative work available to others as provided herein, then
+Licensee hereby agrees to include in any such work a brief summary of
+the changes made to Python.
+
+4. PSF is making Python available to Licensee on an "AS IS"
+basis.  PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND
+DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON WILL NOT
+INFRINGE ANY THIRD PARTY RIGHTS.
+
+5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON
+FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS
+A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON,
+OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+6. This License Agreement will automatically terminate upon a material
+breach of its terms and conditions.
+
+7. Nothing in this License Agreement shall be deemed to create any
+relationship of agency, partnership, or joint venture between PSF and
+Licensee.  This License Agreement does not grant permission to use PSF
+trademarks or trade name in a trademark sense to endorse or promote
+products or services of Licensee, or any third party.
+
+8. By copying, installing or otherwise using Python, Licensee
+agrees to be bound by the terms and conditions of this License
+Agreement.

--- a/debbuild-macros.spec
+++ b/debbuild-macros.spec
@@ -94,6 +94,7 @@ with Debian Policy.
 mkdir -p %{buildroot}%{_debconfigdir}
 cp -av gpgverify %{buildroot}%{_debconfigdir}
 cp -av cmake/cmake-* %{buildroot}%{_debconfigdir}
+cp -av python/pathfix.py %{buildroot}%{_debconfigdir}
 cp -av sysusers.generate-pre.sh %{buildroot}%{_debconfigdir}
 mkdir -p %{buildroot}%{_debmacrodir}
 cp -av macros.* %{buildroot}%{_debmacrodir}

--- a/macros.python
+++ b/macros.python
@@ -6,7 +6,13 @@
 %python_version %(%{__python} -c "import sys; sys.stdout.write(sys.version[:3])")
 
 %py_setup setup.py
-%py_shbang_opts -s
+
+%_py_shebang_s s
+%_py_shebang_P %(RPM_BUILD_ROOT= %{__python} -Esc "import sys; print('P' if hasattr(sys.flags, 'safe_path') else '')")
+%py_shbang_opts -%{?_py_shebang_s}%{?_py_shebang_P}
+%py_shbang_opts_nodash %(opts=%{py_shbang_opts}; echo ${opts#-})
+%py_shebang_flags %(opts=%{py_shbang_opts}; echo ${opts#-})
+%py_shebang_fix  %{__python} -B %{_debconfigdir}/pathfix.py -pni %{__python} -ka%{py_shebang_flags}
 
 %py_build CFLAGS="%{optflags}" %{__python} %{py_setup} %{?py_setup_args} build --executable="%{__python} %{py_shbang_opts}"
 %py_install %{__python} %{py_setup} %{?py_setup_args} install --no-compile -O0 --skip-build --root %{buildroot} --install-layout=deb

--- a/macros.python2
+++ b/macros.python2
@@ -7,7 +7,12 @@
 %python2_version_nodots %(%{__python2} -Esc "import sys; sys.stdout.write('{0.major}{0.minor}'.format(sys.version_info))")
 %python2_pkgversion %{nil}
 
-%py2_shbang_opts -s
+%_py2_shebang_s s
+%_py2_shebang_P %(RPM_BUILD_ROOT= %{__python2} -Esc "import sys; print('P' if hasattr(sys.flags, 'safe_path') else '')")
+%py2_shbang_opts -%{?_py2_shebang_s}%{?_py2_shebang_P}
+%py2_shbang_opts_nodash %(opts=%{py2_shbang_opts}; echo ${opts#-})
+%py2_shebang_flags %(opts=%{py2_shbang_opts}; echo ${opts#-})
+%py2_shebang_fix  %{__python2} -B %{_debconfigdir}/pathfix.py -pni %{__python2} -ka%{py2_shebang_flags}
 
 %py2_build CFLAGS="%{optflags}" %{__python2} %{py_setup} %{?py_setup_args} build --executable="%{__python2} %{py2_shbang_opts}"
 %py2_install %{__python2} %{py_setup} %{?py_setup_args} install --no-compile -O0 --skip-build --root %{buildroot} --install-layout=deb

--- a/macros.python3
+++ b/macros.python3
@@ -7,7 +7,12 @@
 %python3_version_nodots %(%{__python3} -Esc "import sys; sys.stdout.write('{0.major}{0.minor}'.format(sys.version_info))")
 %python3_pkgversion 3
 
-%py3_shbang_opts -s
+%_py3_shebang_s s
+%_py3_shebang_P %(RPM_BUILD_ROOT= %{__python3} -Esc "import sys; print('P' if hasattr(sys.flags, 'safe_path') else '')")
+%py3_shbang_opts -%{?_py3_shebang_s}%{?_py3_shebang_P}
+%py3_shbang_opts_nodash %(opts=%{py3_shbang_opts}; echo ${opts#-})
+%py3_shebang_flags %(opts=%{py3_shbang_opts}; echo ${opts#-})
+%py3_shebang_fix  %{__python3} -B %{_debconfigdir}/pathfix.py -pni %{__python3} -ka%{py3_shebang_flags}
 
 %py3_build CFLAGS="%{optflags}" %{__python3} %{py_setup} %{?py_setup_args} build --executable="%{__python3} %{py3_shbang_opts}"
 %py3_install %{__python3} %{py_setup} %{?py_setup_args} install --no-compile -O0 --skip-build --root %{buildroot} --install-layout=deb

--- a/python/pathfix.py
+++ b/python/pathfix.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+
+# Split out from Python's source tree
+# SPDX-License-Identifier: PSF-2.0
+
+import sys
+import os
+from stat import *
+import getopt
+
+err = sys.stderr.write
+dbg = err
+rep = sys.stdout.write
+
+new_interpreter = None
+preserve_timestamps = False
+create_backup = True
+keep_flags = False
+add_flags = b''
+
+
+def main():
+    global new_interpreter
+    global preserve_timestamps
+    global create_backup
+    global keep_flags
+    global add_flags
+
+    usage = ('usage: %s -i /interpreter -p -n -k -a file-or-directory ...\n' %
+             sys.argv[0])
+    try:
+        opts, args = getopt.getopt(sys.argv[1:], 'i:a:kpn')
+    except getopt.error as msg:
+        err(str(msg) + '\n')
+        err(usage)
+        sys.exit(2)
+    for o, a in opts:
+        if o == '-i':
+            new_interpreter = a.encode()
+        if o == '-p':
+            preserve_timestamps = True
+        if o == '-n':
+            create_backup = False
+        if o == '-k':
+            keep_flags = True
+        if o == '-a':
+            add_flags = a.encode()
+            if b' ' in add_flags:
+                err("-a option doesn't support whitespaces")
+                sys.exit(2)
+    if not new_interpreter or not new_interpreter.startswith(b'/') or \
+           not args:
+        err('-i option or file-or-directory missing\n')
+        err(usage)
+        sys.exit(2)
+    bad = 0
+    for arg in args:
+        if os.path.isdir(arg):
+            if recursedown(arg): bad = 1
+        elif os.path.islink(arg):
+            err(arg + ': will not process symbolic links\n')
+            bad = 1
+        else:
+            if fix(arg): bad = 1
+    sys.exit(bad)
+
+
+def ispython(name):
+    return name.endswith('.py')
+
+
+def recursedown(dirname):
+    dbg('recursedown(%r)\n' % (dirname,))
+    bad = 0
+    try:
+        names = os.listdir(dirname)
+    except OSError as msg:
+        err('%s: cannot list directory: %r\n' % (dirname, msg))
+        return 1
+    names.sort()
+    subdirs = []
+    for name in names:
+        if name in (os.curdir, os.pardir): continue
+        fullname = os.path.join(dirname, name)
+        if os.path.islink(fullname): pass
+        elif os.path.isdir(fullname):
+            subdirs.append(fullname)
+        elif ispython(name):
+            if fix(fullname): bad = 1
+    for fullname in subdirs:
+        if recursedown(fullname): bad = 1
+    return bad
+
+
+def fix(filename):
+##  dbg('fix(%r)\n' % (filename,))
+    try:
+        f = open(filename, 'rb')
+    except IOError as msg:
+        err('%s: cannot open: %r\n' % (filename, msg))
+        return 1
+    with f:
+        line = f.readline()
+        fixed = fixline(line)
+        if line == fixed:
+            rep(filename+': no change\n')
+            return
+        head, tail = os.path.split(filename)
+        tempname = os.path.join(head, '@' + tail)
+        try:
+            g = open(tempname, 'wb')
+        except IOError as msg:
+            err('%s: cannot create: %r\n' % (tempname, msg))
+            return 1
+        with g:
+            rep(filename + ': updating\n')
+            g.write(fixed)
+            BUFSIZE = 8*1024
+            while 1:
+                buf = f.read(BUFSIZE)
+                if not buf: break
+                g.write(buf)
+
+    # Finishing touch -- move files
+
+    mtime = None
+    atime = None
+    # First copy the file's mode to the temp file
+    try:
+        statbuf = os.stat(filename)
+        mtime = statbuf.st_mtime
+        atime = statbuf.st_atime
+        os.chmod(tempname, statbuf[ST_MODE] & 0o7777)
+    except OSError as msg:
+        err('%s: warning: chmod failed (%r)\n' % (tempname, msg))
+    # Then make a backup of the original file as filename~
+    if create_backup:
+        try:
+            os.rename(filename, filename + '~')
+        except OSError as msg:
+            err('%s: warning: backup failed (%r)\n' % (filename, msg))
+    else:
+        try:
+            os.remove(filename)
+        except OSError as msg:
+            err('%s: warning: removing failed (%r)\n' % (filename, msg))
+    # Now move the temp file to the original file
+    try:
+        os.rename(tempname, filename)
+    except OSError as msg:
+        err('%s: rename failed (%r)\n' % (filename, msg))
+        return 1
+    if preserve_timestamps:
+        if atime and mtime:
+            try:
+                os.utime(filename, (atime, mtime))
+            except OSError as msg:
+                err('%s: reset of timestamp failed (%r)\n' % (filename, msg))
+                return 1
+    # Return success
+    return 0
+
+
+def parse_shebang(shebangline):
+    shebangline = shebangline.rstrip(b'\n')
+    start = shebangline.find(b' -')
+    if start == -1:
+        return b''
+    return shebangline[start:]
+
+
+def populate_flags(shebangline):
+    old_flags = b''
+    if keep_flags:
+        old_flags = parse_shebang(shebangline)
+        if old_flags:
+            old_flags = old_flags[2:]
+    if not (old_flags or add_flags):
+        return b''
+    # On Linux, the entire string following the interpreter name
+    # is passed as a single argument to the interpreter.
+    # e.g. "#! /usr/bin/python3 -W Error -s" runs "/usr/bin/python3 "-W Error -s"
+    # so shebang should have single '-' where flags are given and
+    # flag might need argument for that reasons adding new flags is
+    # between '-' and original flags
+    # e.g. #! /usr/bin/python3 -sW Error
+    return b' -' + add_flags + old_flags
+
+
+def fixline(line):
+    if not line.startswith(b'#!'):
+        return line
+
+    if b"python" not in line:
+        return line
+
+    flags = populate_flags(line)
+    return b'#! ' + new_interpreter + flags + b'\n'
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This is used for packaging Python code to correctly target the interpreter in installed code.